### PR TITLE
Expose public materialized view query API

### DIFF
--- a/src/package.lisp
+++ b/src/package.lisp
@@ -40,5 +40,7 @@
    :database-view :new-view :add-view :delete-view :clear-view :create-view-db
    :define-map :define-reduce :insert-results :apply-view
    :apply-view-to-database :with-views
+   :view-get :view-rows :map-view :reduce-view
+   :view-reducer-missing :view-reducer-missing-view
    ;; encoding
    :%* :$))

--- a/src/views.lisp
+++ b/src/views.lisp
@@ -11,6 +11,12 @@
              (format stream "Tek9 view mapper failed: ~A"
                      (view-error-cause condition)))))
 
+(define-condition view-reducer-missing (error)
+  ((view :initarg :view :reader view-reducer-missing-view))
+  (:report (lambda (condition stream)
+             (format stream "Tek9 view ~S has no reducer."
+                     (view-name (view-reducer-missing-view condition))))))
+
 (defclass database-view ()
   ((name :initform "" :type string :accessor view-name :initarg :name)
    (map-fn :initform nil :accessor view-map :initarg :map)
@@ -136,6 +142,59 @@ The named LMDB DBI is retained because closing/deleting open DBIs is unsafe."
             (dolist (row (funcall (view-map view) (%decode-document bytes)))
               (lmdb:put target (car row) (%* (cdr row))))))))
     view))
+
+(defun view-get (database view key &optional default)
+  "Return the decoded materialized value for KEY in VIEW.
+
+Return DEFAULT and NIL when KEY is absent; otherwise return VALUE and T. Callers
+do not need to know that views are currently stored in LMDB."
+  (let ((db (create-view-db database view)))
+    (with-database (database)
+      (let ((bytes (lmdb:g3t db key)))
+        (if bytes
+            (values ($ bytes) t)
+            (values default nil))))))
+
+(defun view-rows (database view &key start end limit)
+  "Return decoded materialized rows from VIEW as (KEY . VALUE) conses.
+
+Rows are returned in storage key order. START is inclusive and END is exclusive.
+LIMIT, when non-NIL, bounds the number of returned rows. The public contract is
+independent of LMDB cursor details."
+  (when (and limit (minusp limit))
+    (error "VIEW-ROWS LIMIT must be non-negative or NIL."))
+  (let ((db (create-view-db database view))
+        (rows nil)
+        (count 0))
+    (with-database (database)
+      (lmdb:do-db (key bytes db :nodup t)
+        (when (and (or (null start) (not (string< key start)))
+                   (or (null end) (string< key end))
+                   (or (null limit) (< count limit)))
+          (push (cons key ($ bytes)) rows)
+          (incf count))))
+    (nreverse rows)))
+
+(defun map-view (database view function &key start end limit)
+  "Call FUNCTION with KEY and decoded VALUE for each selected materialized row.
+
+Return the number of rows visited. START/END/LIMIT have the same semantics as
+VIEW-ROWS."
+  (let ((count 0))
+    (dolist (row (view-rows database view :start start :end end :limit limit) count)
+      (funcall function (car row) (cdr row))
+      (incf count))))
+
+(defun reduce-view (database view &key start end limit)
+  "Apply VIEW's reducer to selected decoded materialized rows.
+
+Signal VIEW-REDUCER-MISSING when VIEW has no reducer. Reducers receive the same
+(KEY . VALUE) row shape returned by VIEW-ROWS."
+  (let ((reducer (view-reduce view)))
+    (unless reducer
+      (error 'view-reducer-missing :view view))
+    (funcall reducer
+             (view-rows database view :start start :end end :limit limit))))
 
 (defmacro with-views (database views &body body)
   "Execute BODY, then incrementally update VIEWS from Tek9's change vector."

--- a/tests/test-views.lisp
+++ b/tests/test-views.lisp
@@ -32,9 +32,9 @@
              (is (not found-p))
              (is (eq :missing value)))
 
-           (is (equal '(#1=("p1" . "Ada") ("p3" . "Lin"))
+           (is (equal '(("p1" . "Ada") ("p3" . "Lin"))
                       (view-rows db view)))
-           (is (equal '(#1#)
+           (is (equal '(("p1" . "Ada"))
                       (view-rows db view :start "p1" :end "p3")))
            (is (equal '(("p3" . "Lin"))
                       (view-rows db view :start "p3" :limit 1)))

--- a/tests/test-views.lisp
+++ b/tests/test-views.lisp
@@ -11,40 +11,78 @@
                (emit (doc-id doc) (getf (doc-value doc) :name))))
            (define-reduce view
              (length rows))
-           (is (= 3 (funcall (tek9::view-reduce view) '(a b c))))
            (add-view db view)
 
            (put-bulk db
                      (list (new-document :id "p1"
                                          :value '(:dtype "person" :name "Ada"))
+                           (new-document :id "p3"
+                                         :value '(:dtype "person" :name "Lin"))
                            (new-document :id "o1"
                                          :value '(:dtype "organization" :name "ACME"))))
            (apply-view-to-database db view)
 
-           (let ((view-db (create-view-db db view)))
-             (with-database (db)
-               (is (string= "Ada" (tek9:$ (lmdb:g3t view-db "p1"))))
-               (is (null (lmdb:g3t view-db "o1")))))
+           ;; Normal readers no longer reach through Tek9 into raw LMDB.
+           (multiple-value-bind (value found-p)
+               (view-get db view "p1")
+             (is found-p)
+             (is (string= "Ada" value)))
+           (multiple-value-bind (value found-p)
+               (view-get db view "o1" :missing)
+             (is (not found-p))
+             (is (eq :missing value)))
+
+           (is (equal '(#1=("p1" . "Ada") ("p3" . "Lin"))
+                      (view-rows db view)))
+           (is (equal '(#1#)
+                      (view-rows db view :start "p1" :end "p3")))
+           (is (equal '(("p3" . "Lin"))
+                      (view-rows db view :start "p3" :limit 1)))
+
+           (let (visited)
+             (is (= 2 (map-view db view
+                                (lambda (key value)
+                                  (push (cons key value) visited)))))
+             (is (equal '(("p1" . "Ada") ("p3" . "Lin"))
+                        (nreverse visited))))
+           (is (= 2 (reduce-view db view)))
+           (is (= 1 (reduce-view db view :start "p3")))
 
            ;; A rebuild must clear rows that no longer match the mapper.
            (put db (new-document :id "p1"
                                  :value '(:dtype "organization" :name "Ada")))
            (apply-view-to-database db view)
-           (let ((view-db (create-view-db db view)))
-             (with-database (db)
-               (is (null (lmdb:g3t view-db "p1")))))
+           (multiple-value-bind (value found-p)
+               (view-get db view "p1")
+             (declare (ignore value))
+             (is (not found-p)))
 
            ;; WITH-VIEWS applies touched document ids and then clears the change vector.
            (with-views db (list view)
              (put db (new-document :id "p2"
                                    :value '(:dtype "person" :name "Grace"))))
-           (let ((view-db (create-view-db db view)))
-             (with-database (db)
-               (is (string= "Grace" (tek9:$ (lmdb:g3t view-db "p2"))))))
+           (multiple-value-bind (value found-p)
+               (view-get db view "p2")
+             (is found-p)
+             (is (string= "Grace" value)))
            (is (zerop (length (db-changed db))))
 
            (is (delete-view db view))
-           (let ((view-db (create-view-db db view)))
-             (with-database (db)
-               (is (null (lmdb:g3t view-db "p2"))))))
+           (multiple-value-bind (value found-p)
+               (view-get db view "p2")
+             (declare (ignore value))
+             (is (not found-p))))
+      (close-database db))))
+
+(test view-reducer-missing-condition
+  (let ((db (setup-db #P"/tmp/test-tek9-view-no-reducer/")))
+    (unwind-protect
+         (let ((view (new-view "no-reducer" nil)))
+           (define-map view
+             (emit (doc-id doc) (doc-value doc)))
+           (add-view db view)
+           (put db (new-document :id "x" :value "value"))
+           (apply-view-to-database db view)
+           (signals view-reducer-missing
+             (reduce-view db view)))
       (close-database db))))

--- a/tests/test-views.lisp
+++ b/tests/test-views.lisp
@@ -25,7 +25,7 @@
            ;; Normal readers no longer reach through Tek9 into raw LMDB.
            (multiple-value-bind (value found-p)
                (view-get db view "p1")
-             (is found-p)
+             (is (not (null found-p)))
              (is (string= "Ada" value)))
            (multiple-value-bind (value found-p)
                (view-get db view "o1" :missing)
@@ -63,7 +63,7 @@
                                    :value '(:dtype "person" :name "Grace"))))
            (multiple-value-bind (value found-p)
                (view-get db view "p2")
-             (is found-p)
+             (is (not (null found-p)))
              (is (string= "Grace" value)))
            (is (zerop (length (db-changed db))))
 


### PR DESCRIPTION
## Summary
Implements #2 by adding a public read/query layer over Tek9 materialized views so clients no longer depend on LMDB DBI details.

### API
- `view-get` — exact key lookup, decoded value + found flag
- `view-rows` — ordered decoded row scan with inclusive `start`, exclusive `end`, and optional `limit`
- `map-view` — callback iteration over selected rows
- `reduce-view` — invoke a view reducer over selected public row shapes
- `view-reducer-missing` — explicit condition when reduction is requested without a reducer

The public row shape is `(key . value)` and values pass through Tek9's existing codec.

### Ownership
This is intentionally generic Tek9 functionality. Investigation-specific view names such as `assets/by-type` or `ingest/by-state` remain Hackmode-owned (lost-rob0t/hackmode#15).

### Tests
Updates view tests to exercise normal reads exclusively through the public API:
- exact hit/miss/default
- full ordered rows
- range + limit
- callback iteration
- reduction
- missing reducer condition
- rebuild clearing stale rows
- incremental `with-views` update
- delete/clear behavior

Closes #2 when CI is green.