### PR TITLE
Add composable transactions and graph lifecycle APIs

### DIFF
--- a/TRANSACTIONS.org
+++ b/TRANSACTIONS.org
@@ -31,6 +31,8 @@ Compatible nested Tek9 transaction boundaries on the same =database= object reus
 
 A read boundary may run inside a write boundary. A write operation or write boundary inside an active Tek9 read-only transaction signals =transaction-mode-error=.
 
+A Tek9 transaction belongs to exactly one =database= object and its LMDB environment. Attempting to access or nest a different Tek9 database while a transaction is active signals =transaction-database-error=. Tek9 deliberately fails closed rather than pretending two independently committing LMDB environments form one atomic transaction.
+
 The transaction object itself is deliberately not exposed. Consumers should not call raw =lmdb:*= functions or depend on Tek9 DBIs.
 
 ** First-use named document DBs

--- a/TRANSACTIONS.org
+++ b/TRANSACTIONS.org
@@ -1,0 +1,95 @@
+#+title: Tek9 Transaction and Graph Lifecycle APIs
+
+* Composable transactions
+
+Tek9 public document, index, graph, and view operations can participate in one explicit LMDB transaction through =with-write-transaction= and =with-read-transaction=.
+
+#+begin_src lisp
+(with-write-transaction (*db*)
+  (put *db* (new-document :id "person:1"
+                          :value '(:dtype "person" :name "Ada")))
+  (put-nodes *db*
+             (list (make-instance 'node :id "a")
+                   (make-instance 'node :id "b"))
+             :database-name "investigation")
+  (put-edge *db*
+            (make-instance 'edge
+                           :id "e1"
+                           :source "a"
+                           :predicate "knows"
+                           :target "b")
+            :database-name "investigation"))
+#+end_src
+
+Normal return commits the transaction. A condition or other non-local exit aborts the entire transaction, including mixed document, secondary-index, graph-row, and adjacency changes.
+
+Existing standalone public operations keep their old behavior: when there is no active Tek9 transaction they create and commit one LMDB transaction themselves.
+
+** Nested calls
+
+Compatible nested Tek9 transaction boundaries on the same =database= object reuse the active transaction instead of creating child commit boundaries.
+
+A read boundary may run inside a write boundary. A write operation or write boundary inside an active Tek9 read-only transaction signals =transaction-mode-error=.
+
+The transaction object itself is deliberately not exposed. Consumers should not call raw =lmdb:*= functions or depend on Tek9 DBIs.
+
+** First-use named document DBs
+
+The LMDB Common Lisp wrapper does not allow a new named DBI to be opened for the first time after a transaction has begun. Tek9 pre-opens its fixed graph keyspaces and registered view keyspaces before an explicit outer transaction.
+
+If an application uses a custom document =database-name= for the first time inside an explicit transaction, declare that name on the outer boundary:
+
+#+begin_src lisp
+(with-write-transaction (*db* :database-names '("metadata" "journal"))
+  (put *db* (new-document :id "meta" :value '(:revision 2))
+       :database-name "metadata")
+  (put *db* (new-document :id "journal:2" :value '(:operation "op-2"))
+       :database-name "journal"))
+#+end_src
+
+Nested boundaries cannot retroactively open a first-use DBI. Declare first-use custom names on the outermost boundary.
+
+* Graph lifecycle
+
+Graph/v2 continues to expose logical graph names and external string IDs. Internal uint64 row IDs, mapping key formats, and LMDB DBIs remain private.
+
+** Fetch one edge
+
+#+begin_src lisp
+(fetch-edge *db* "edge-42" :database-name "investigation")
+#+end_src
+
+The returned edge preserves its external edge ID and normal =edge-source=, =edge-predicate=, and =edge-target= accessors.
+
+** Enumerate one graph namespace
+
+#+begin_src lisp
+(fetch-graph-nodes *db* "investigation")
+(fetch-graph-edges *db* "investigation")
+#+end_src
+
+Both APIs return objects sorted by external ID. Enumeration seeks directly to the logical graph namespace prefix and does not scan unrelated graph mappings.
+
+** Delete a node
+
+#+begin_src lisp
+(delete-node *db* "node-7" :database-name "investigation")
+#+end_src
+
+Deleting a node atomically removes every incident edge and all ordinary plus predicate-specific inbound/outbound adjacency for those edges. Parallel edges remain independently identified and are all removed when incident to the deleted node.
+
+The function returns NIL when the node does not exist and true after a successful deletion.
+
+** Clear one graph
+
+#+begin_src lisp
+(clear-graph *db* "investigation")
+#+end_src
+
+=CLEAR-GRAPH= atomically removes the graph namespace's node mappings, node rows, edge mappings, edge rows, and adjacency records. Other graph namespaces remain untouched even when they reuse the same external node or edge IDs.
+
+Global monotonically allocated graph row counters and predicate dictionary rows are retained. They are engine metadata, not logical membership in the cleared graph.
+
+* Durability
+
+These APIs use the database's configured durability profile. Canonical application data should use Tek9's default =:full= durability. Do not select =:nosync= merely to reduce benchmark latency.

--- a/src/graph-lifecycle.lisp
+++ b/src/graph-lifecycle.lisp
@@ -1,0 +1,151 @@
+(in-package :tek9)
+
+(defmethod prepare-transaction-dbis :after ((database database) &key database-names)
+  (declare (ignore database-names))
+  ;; LMDB's Common Lisp wrapper rejects first-time GET-DB while a transaction
+  ;; is active. Graph/v2 uses a fixed physical keyspace, so opening those DBIs
+  ;; here is bounded and keeps the layout private from callers.
+  (ensure-graph-dbs database)
+  ;; Registered views have similarly stable process-local identities.
+  (loop for view being the hash-values of (db-views database)
+        do (create-view-db database view)))
+
+(defun %string-prefix-p (prefix string)
+  (let ((prefix-length (length prefix)))
+    (and (<= prefix-length (length string))
+         (string= prefix string :end2 prefix-length))))
+
+(defun %decode-key-part-at (key start)
+  (let ((colon (position #\: key :start start)))
+    (unless colon
+      (error "Malformed Tek9 composite graph key ~S." key))
+    (let* ((length (parse-integer key :start start :end colon))
+           (value-start (1+ colon))
+           (value-end (+ value-start length)))
+      (when (> value-end (length key))
+        (error "Malformed Tek9 composite graph key ~S." key))
+      (values (subseq key value-start value-end) value-end))))
+
+(defun %external-id-from-mapping-key (graph-name key)
+  (multiple-value-bind (stored-graph next)
+      (%decode-key-part-at key 0)
+    (unless (string= graph-name stored-graph)
+      (error "Graph mapping key ~S belongs to ~S, not ~S."
+             key stored-graph graph-name))
+    (multiple-value-bind (external-id end)
+        (%decode-key-part-at key next)
+      (unless (= end (length key))
+        (error "Malformed trailing bytes in Tek9 graph key ~S." key))
+      external-id)))
+
+(defun %graph-mapping-entries (mapping-db graph-name)
+  "Return (EXTERNAL-ID . ROW-ID) entries for GRAPH-NAME in key order.
+
+The cursor seeks to the graph prefix instead of scanning unrelated graph
+namespaces. Must be called inside an active transaction."
+  (let ((prefix (%key-part graph-name))
+        (entries nil))
+    (lmdb:with-cursor (cursor mapping-db)
+      (multiple-value-bind (key row found)
+          (lmdb:cursor-set-range prefix cursor)
+        (loop while (and found (%string-prefix-p prefix key))
+              do (push (cons (%external-id-from-mapping-key graph-name key) row)
+                       entries)
+                 (multiple-value-setq (key row found)
+                   (lmdb:cursor-next cursor)))))
+    (nreverse entries)))
+
+(defun fetch-edge (database id &key (database-name (get-default-graph-db)))
+  "Fetch one EDGE by stable external ID from logical graph DATABASE-NAME."
+  (let ((dbis (ensure-graph-dbs database)))
+    (with-database (database)
+      (let ((row (%lookup-edge-row dbis database-name id)))
+        (and row
+             (%decode-document-or-object
+              (lmdb:g3t (graph-dbis-edges dbis) row)))))))
+
+(defun fetch-graph-nodes (database database-name)
+  "Return every NODE in logical graph DATABASE-NAME, sorted by external ID."
+  (let ((dbis (ensure-graph-dbs database)))
+    (with-database (database)
+      (sort
+       (loop for (external-id . row)
+               in (%graph-mapping-entries (graph-dbis-node-map dbis) database-name)
+             for bytes = (lmdb:g3t (graph-dbis-nodes dbis) row)
+             when bytes
+               collect (%decode-document-or-object bytes)
+             else
+               do (warn "Tek9 graph ~S node mapping ~S points to missing row ~D."
+                        database-name external-id row))
+       #'string< :key #'node-id))))
+
+(defun fetch-graph-edges (database database-name)
+  "Return every EDGE in logical graph DATABASE-NAME, sorted by external ID."
+  (let ((dbis (ensure-graph-dbs database)))
+    (with-database (database)
+      (sort
+       (loop for (external-id . row)
+               in (%graph-mapping-entries (graph-dbis-edge-map dbis) database-name)
+             for bytes = (lmdb:g3t (graph-dbis-edges dbis) row)
+             when bytes
+               collect (%decode-document-or-object bytes)
+             else
+               do (warn "Tek9 graph ~S edge mapping ~S points to missing row ~D."
+                        database-name external-id row))
+       #'string< :key #'edge-id))))
+
+(defun delete-node (database id &key (database-name (get-default-graph-db)))
+  "Delete node ID and all of its incident edges atomically.
+
+Every normal and predicate-specific inbound/outbound adjacency record is removed
+through DELETE-EDGE before the node row and external mapping are deleted."
+  (let ((dbis (ensure-graph-dbs database)))
+    (with-database (database :write t)
+      (let ((row (%lookup-node-row dbis database-name id)))
+        (unless row
+          (return-from delete-node nil))
+        (let ((edge-ids
+                (remove-duplicates
+                 (append (fetch-node-edge-ids database id
+                                              :database-name database-name)
+                         (fetch-node-edge-ids database id
+                                              :database-name database-name
+                                              :incoming t))
+                 :test #'string=)))
+          (dolist (edge-id edge-ids)
+            (let ((edge (fetch-edge database edge-id
+                                    :database-name database-name)))
+              (when edge
+                (delete-edge database edge :database-name database-name)))))
+        (lmdb:del (graph-dbis-nodes dbis) row)
+        (lmdb:del (graph-dbis-node-map dbis)
+                  (%external-node-key database-name id))
+        t))))
+
+(defun clear-graph (database database-name)
+  "Remove all topology owned by logical graph DATABASE-NAME atomically.
+
+Other graph namespaces, including ones reusing the same external node or edge
+IDs, are untouched. Global monotonic row counters and predicate dictionary rows
+are intentionally retained."
+  (let ((dbis (ensure-graph-dbs database)))
+    (with-database (database :write t)
+      (let ((edge-entries
+              (%graph-mapping-entries (graph-dbis-edge-map dbis) database-name))
+            (node-entries
+              (%graph-mapping-entries (graph-dbis-node-map dbis) database-name)))
+        (dolist (entry edge-entries)
+          (let* ((external-id (car entry))
+                 (row (cdr entry))
+                 (bytes (lmdb:g3t (graph-dbis-edges dbis) row)))
+            (when bytes
+              (%remove-edge-adjacency
+               dbis database-name row (%decode-document-or-object bytes)))
+            (lmdb:del (graph-dbis-edges dbis) row)
+            (lmdb:del (graph-dbis-edge-map dbis)
+                      (%external-edge-key database-name external-id))))
+        (dolist (entry node-entries)
+          (lmdb:del (graph-dbis-nodes dbis) (cdr entry))
+          (lmdb:del (graph-dbis-node-map dbis)
+                    (%external-node-key database-name (car entry))))
+        t))))

--- a/src/objects.lisp
+++ b/src/objects.lisp
@@ -35,7 +35,7 @@
                                (key-type :string)
                                unique
                                multi-valued)
-  "Create a reusable declarative secondary-index definition.
+  "Create a reusable declarative INDEX-DEFINITION.
 
 INDEX-DEFINITION objects contain Lisp extractor functions, so they are process
 configuration rather than serialized database metadata. OPEN-DATABASE reapplies
@@ -218,17 +218,108 @@ provided, a DB configured with :DEFAULT reads *INDEX-DEFINITIONS* at open time."
   (clrhash (db-indexes db))
   db)
 
-(defmacro with-database ((database &key (write nil)) &body body)
-  "Execute BODY in one LMDB transaction using DATABASE's durability profile.
+(define-condition transaction-mode-error (error)
+  ((database :initarg :database :reader transaction-mode-error-database)
+   (requested-mode :initarg :requested-mode
+                   :reader transaction-mode-error-requested-mode)
+   (active-mode :initarg :active-mode
+                :reader transaction-mode-error-active-mode))
+  (:report (lambda (condition stream)
+             (format stream
+                     "Cannot start Tek9 ~A work inside an active ~A transaction on ~A."
+                     (transaction-mode-error-requested-mode condition)
+                     (transaction-mode-error-active-mode condition)
+                     (db-name (transaction-mode-error-database condition))))))
 
-WITH-TXN commits automatically on normal return and aborts on non-local exit."
-  `(multiple-value-bind (sync meta-sync)
-       (durability-options (db-durability ,database))
-     (lmdb:with-txn (:env (db-env ,database)
-                     :write ,write
-                     :sync sync
-                     :meta-sync meta-sync)
-       ,@body)))
+(defvar *transaction-database* nil
+  "DATABASE whose Tek9 transaction boundary is active in this dynamic extent.")
+
+(defvar *transaction-mode* nil
+  "Mode of the active Tek9 transaction boundary: :READ or :WRITE.")
+
+(defgeneric prepare-transaction-dbis (database &key database-names)
+  (:documentation
+   "Open DBIs required by an explicit Tek9 transaction before LMDB begins it.
+
+The LMDB wrapper forbids first-time GET-DB calls inside an active transaction.
+Methods may therefore pre-open fixed engine keyspaces. DATABASE-NAMES declares
+additional document keyspaces the caller intends to use."))
+
+(defmethod prepare-transaction-dbis ((database database) &key database-names)
+  (database-db database +main-name+
+               :key-encoding :utf-8
+               :value-encoding :octets)
+  (dolist (name database-names database)
+    (database-db database name
+                 :key-encoding :utf-8
+                 :value-encoding :octets)))
+
+(defun call-with-database-transaction (database write function)
+  "Call FUNCTION in a compatible Tek9 transaction on DATABASE.
+
+Standalone operations create one LMDB transaction. When called within an
+existing Tek9 transaction for the same DATABASE, compatible work reuses that
+transaction directly instead of creating an LMDB child transaction."
+  (check-type function function)
+  (if (eq database *transaction-database*)
+      (progn
+        (when (and write (eq *transaction-mode* :read))
+          (error 'transaction-mode-error
+                 :database database
+                 :requested-mode :write
+                 :active-mode :read))
+        (funcall function))
+      (multiple-value-bind (sync meta-sync)
+          (durability-options (db-durability database))
+        (lmdb:with-txn (:env (db-env database)
+                        :write write
+                        :sync sync
+                        :meta-sync meta-sync)
+          (let ((*transaction-database* database)
+                (*transaction-mode* (if write :write :read)))
+            (funcall function))))))
+
+(defmacro with-database ((database &key (write nil)) &body body)
+  "Execute BODY in a Tek9 transaction, reusing a compatible active boundary.
+
+On a normal standalone call this creates one LMDB transaction using DATABASE's
+durability profile. Inside an explicit Tek9 transaction for the same DATABASE,
+BODY participates directly in the active transaction."
+  (let ((database-var (gensym "DATABASE")))
+    `(let ((,database-var ,database))
+       (call-with-database-transaction
+        ,database-var ,write
+        (lambda () ,@body)))))
+
+(defun call-with-transaction (database function mode &key database-names)
+  "Call FUNCTION in one explicit Tek9 MODE transaction.
+
+MODE is :READ or :WRITE. Fixed engine DBIs and DATABASE-NAMES are opened before
+the outer LMDB transaction begins. Nested compatible Tek9 transactions on the
+same DATABASE reuse the active boundary; callers must declare any first-use
+custom DATABASE-NAMES at the outermost boundary."
+  (check-type function function)
+  (check-type mode (member :read :write))
+  (unless (eq database *transaction-database*)
+    (prepare-transaction-dbis database :database-names database-names))
+  (call-with-database-transaction database (eq mode :write) function))
+
+(defmacro with-read-transaction ((database &key database-names) &body body)
+  "Execute BODY in one composable read transaction on DATABASE."
+  `(call-with-transaction ,database
+                          (lambda () ,@body)
+                          :read
+                          :database-names ,database-names))
+
+(defmacro with-write-transaction ((database &key database-names) &body body)
+  "Execute BODY in one composable write transaction on DATABASE.
+
+All normal Tek9 document, index, graph, and view operations on DATABASE reuse
+this transaction. Non-local exit aborts the entire boundary."
+  `(call-with-transaction ,database
+                          (lambda () ,@body)
+                          :write
+                          :database-names ,database-names))
 
 (defun %ordered-key< (left right)
   (etypecase left
@@ -255,7 +346,8 @@ into a safe optimization hint instead of blindly asserting MDB_APPEND."
   "Return environment and named-database statistics without scanning data."
   (let ((db (database-db database database-name)))
     (list :environment (lmdb:env-info (db-env database))
-          :database (lmdb:db-statistics db))))
+          :database (with-database (database)
+                      (lmdb:db-statistics db)))))
 
 (defun clear-changes (database)
   (setf (fill-pointer (db-changed database)) 0)

--- a/src/objects.lisp
+++ b/src/objects.lisp
@@ -231,6 +231,17 @@ provided, a DB configured with :DEFAULT reads *INDEX-DEFINITIONS* at open time."
                      (transaction-mode-error-active-mode condition)
                      (db-name (transaction-mode-error-database condition))))))
 
+(define-condition transaction-database-error (error)
+  ((active-database :initarg :active-database
+                    :reader transaction-database-error-active-database)
+   (requested-database :initarg :requested-database
+                       :reader transaction-database-error-requested-database))
+  (:report (lambda (condition stream)
+             (format stream
+                     "Cannot access Tek9 database ~A inside a transaction on different database ~A. LMDB cannot provide an atomic transaction across environments."
+                     (db-name (transaction-database-error-requested-database condition))
+                     (db-name (transaction-database-error-active-database condition))))))
+
 (defvar *transaction-database* nil
   "DATABASE whose Tek9 transaction boundary is active in this dynamic extent.")
 
@@ -259,8 +270,15 @@ additional document keyspaces the caller intends to use."))
 
 Standalone operations create one LMDB transaction. When called within an
 existing Tek9 transaction for the same DATABASE, compatible work reuses that
-transaction directly instead of creating an LMDB child transaction."
+transaction directly instead of creating an LMDB child transaction. Access to a
+different DATABASE while a Tek9 transaction is active fails closed because LMDB
+cannot atomically compose transactions across environments."
   (check-type function function)
+  (when (and *transaction-database*
+             (not (eq database *transaction-database*)))
+    (error 'transaction-database-error
+           :active-database *transaction-database*
+           :requested-database database))
   (if (eq database *transaction-database*)
       (progn
         (when (and write (eq *transaction-mode* :read))
@@ -297,9 +315,15 @@ BODY participates directly in the active transaction."
 MODE is :READ or :WRITE. Fixed engine DBIs and DATABASE-NAMES are opened before
 the outer LMDB transaction begins. Nested compatible Tek9 transactions on the
 same DATABASE reuse the active boundary; callers must declare any first-use
-custom DATABASE-NAMES at the outermost boundary."
+custom DATABASE-NAMES at the outermost boundary. Nesting a different DATABASE
+fails closed rather than creating a separately committing LMDB transaction."
   (check-type function function)
   (check-type mode (member :read :write))
+  (when (and *transaction-database*
+             (not (eq database *transaction-database*)))
+    (error 'transaction-database-error
+           :active-database *transaction-database*
+           :requested-database database))
   (unless (eq database *transaction-database*)
     (prepare-transaction-dbis database :database-names database-names))
   (call-with-database-transaction database (eq mode :write) function))

--- a/src/package.lisp
+++ b/src/package.lisp
@@ -9,11 +9,14 @@
                 :href
                 :pophash)
   (:export
-   ;; database
+   ;; database / transaction boundary
    :database :new-database :open-database :close-database :db-is-open-p
    :db-path :db-env :db-name :db-max-size :db-max-dbs :db-max-readers
    :db-durability :db-count :db-changed :db-views :db-index-definitions
    :database-db :database-stats :map-database :with-database :clear-changes
+   :with-read-transaction :with-write-transaction :call-with-transaction
+   :transaction-mode-error :transaction-mode-error-database
+   :transaction-mode-error-requested-mode :transaction-mode-error-active-mode
    ;; declarative indexes
    :index-definition :new-index-definition :*index-definitions*
    :index-definition-name :index-definition-key-fn
@@ -34,8 +37,9 @@
    :node :node-id :node-props :node-edges :edge :edge-id :edge-source
    :edge-predicate :edge-target :edge-key :get-default-graph-db :get-graph-db
    :put-node :put-nodes :fetch-node :fetch-bulk-nodes :add-node-edge :put-edge
-   :put-edges :put-edges* :fetch-node-edge-ids :fetch-node-edges
-   :fetch-node-neighbors :delete-edge
+   :put-edges :put-edges* :fetch-edge :fetch-graph-nodes :fetch-graph-edges
+   :fetch-node-edge-ids :fetch-node-edges :fetch-node-neighbors
+   :delete-edge :delete-node :clear-graph
    ;; views
    :database-view :new-view :add-view :delete-view :clear-view :create-view-db
    :define-map :define-reduce :insert-results :apply-view

--- a/src/package.lisp
+++ b/src/package.lisp
@@ -17,6 +17,9 @@
    :with-read-transaction :with-write-transaction :call-with-transaction
    :transaction-mode-error :transaction-mode-error-database
    :transaction-mode-error-requested-mode :transaction-mode-error-active-mode
+   :transaction-database-error
+   :transaction-database-error-active-database
+   :transaction-database-error-requested-database
    ;; declarative indexes
    :index-definition :new-index-definition :*index-definitions*
    :index-definition-name :index-definition-key-fn

--- a/src/tek9.asd
+++ b/src/tek9.asd
@@ -12,5 +12,6 @@
                (:file "graphs")
                (:file "views")
                (:file "query")
+               (:file "graph-lifecycle")
                (:file "tek9"))
   :in-order-to ((test-op (test-op :tek9-tests))))

--- a/tests/tek9-tests.asd
+++ b/tests/tek9-tests.asd
@@ -10,6 +10,8 @@
                (:file "test-documents")
                (:file "test-indexes")
                (:file "test-graphs")
+               (:file "test-transactions")
+               (:file "test-graph-lifecycle")
                (:file "test-views")
                (:file "test-persistence"))
   :perform (test-op (operation component)

--- a/tests/test-graph-lifecycle.lisp
+++ b/tests/test-graph-lifecycle.lisp
@@ -1,0 +1,121 @@
+(in-package :tek9-tests)
+(in-suite :tek9-tests)
+
+(test graph-fetch-and-enumeration
+  (let ((db (setup-db #P"/tmp/test-tek9-graph-enumeration/"))
+        (graph-name "enumerate"))
+    (unwind-protect
+         (progn
+           (put-nodes db
+                      (list (make-instance 'node :id "c")
+                            (make-instance 'node :id "a")
+                            (make-instance 'node :id "b"))
+                      :database-name graph-name)
+           (put-edges db
+                      (list (make-instance 'edge :id "e2" :source "a"
+                                                :predicate "knows" :target "c")
+                            (make-instance 'edge :id "e1" :source "a"
+                                                :predicate "knows" :target "b"))
+                      :database-name graph-name)
+           (is (equal '("a" "b" "c")
+                      (mapcar #'node-id
+                              (fetch-graph-nodes db graph-name))))
+           (is (equal '("e1" "e2")
+                      (mapcar #'edge-id
+                              (fetch-graph-edges db graph-name))))
+           (let ((edge (fetch-edge db "e1" :database-name graph-name)))
+             (is (string= "a" (edge-source edge)))
+             (is (string= "b" (edge-target edge)))))
+      (close-database db))))
+
+(test delete-node-removes-incident-edges-and-adjacency
+  (let ((db (setup-db #P"/tmp/test-tek9-delete-node/"))
+        (graph-name "delete-node"))
+    (unwind-protect
+         (progn
+           (put-nodes db
+                      (list (make-instance 'node :id "a")
+                            (make-instance 'node :id "b")
+                            (make-instance 'node :id "c"))
+                      :database-name graph-name)
+           (put-edges db
+                      (list (make-instance 'edge :id "ab-1" :source "a"
+                                                :predicate "knows" :target "b")
+                            (make-instance 'edge :id "ab-2" :source "a"
+                                                :predicate "works-with" :target "b")
+                            (make-instance 'edge :id "bc" :source "b"
+                                                :predicate "knows" :target "c")
+                            (make-instance 'edge :id "ac" :source "a"
+                                                :predicate "knows" :target "c"))
+                      :database-name graph-name)
+           (is (delete-node db "b" :database-name graph-name))
+           (is (null (fetch-node db "b" :database-name graph-name)))
+           (is (null (fetch-edge db "ab-1" :database-name graph-name)))
+           (is (null (fetch-edge db "ab-2" :database-name graph-name)))
+           (is (null (fetch-edge db "bc" :database-name graph-name)))
+           (is (not (null (fetch-edge db "ac" :database-name graph-name))))
+           (is (equal '("ac")
+                      (fetch-node-edge-ids db "a" :database-name graph-name)))
+           (is (equal '("ac")
+                      (fetch-node-edge-ids db "c"
+                                           :database-name graph-name
+                                           :incoming t)))
+           (is (null (fetch-node-neighbors db "a"
+                                            :database-name graph-name
+                                            :predicate "works-with"))))
+      (close-database db))))
+
+(test clear-graph-preserves-other-namespaces
+  (let ((db (setup-db #P"/tmp/test-tek9-clear-graph/")))
+    (unwind-protect
+         (progn
+           (dolist (graph-name '("one" "two"))
+             (put-nodes db
+                        (list (make-instance 'node :id "same")
+                              (make-instance 'node :id "target"))
+                        :database-name graph-name)
+             (put-edge db
+                       (make-instance 'edge :id "edge" :source "same"
+                                            :predicate "knows" :target "target")
+                       :database-name graph-name))
+           (is (clear-graph db "one"))
+           (is (null (fetch-graph-nodes db "one")))
+           (is (null (fetch-graph-edges db "one")))
+           (is (null (fetch-node db "same" :database-name "one")))
+           (is (null (fetch-edge db "edge" :database-name "one")))
+           (is (equal '("same" "target")
+                      (mapcar #'node-id (fetch-graph-nodes db "two"))))
+           (is (equal '("edge")
+                      (mapcar #'edge-id (fetch-graph-edges db "two"))))
+           (is (= 1 (length (fetch-node-neighbors db "same"
+                                                  :database-name "two")))))
+      (close-database db))))
+
+(test graph-lifecycle-rollback-and-reopen
+  (let* ((path #P"/tmp/test-tek9-graph-lifecycle-rollback/")
+         (db (setup-db path))
+         (graph-name "durable"))
+    (unwind-protect
+         (progn
+           (put-nodes db
+                      (list (make-instance 'node :id "a")
+                            (make-instance 'node :id "b"))
+                      :database-name graph-name)
+           (put-edge db
+                     (make-instance 'edge :id "edge" :source "a"
+                                          :predicate "knows" :target "b")
+                     :database-name graph-name)
+           (signals error
+             (with-write-transaction (db)
+               (clear-graph db graph-name)
+               (error "abort graph clear")))
+           (is (= 2 (length (fetch-graph-nodes db graph-name))))
+           (is (= 1 (length (fetch-graph-edges db graph-name))))
+           (close-database db)
+           (setf db (open-database (new-database "test" :path path)))
+           (is (equal '("a" "b")
+                      (mapcar #'node-id (fetch-graph-nodes db graph-name))))
+           (is (equal '("edge")
+                      (mapcar #'edge-id (fetch-graph-edges db graph-name)))))
+      (when (and db (db-is-open-p db))
+        (close-database db)))))

--- a/tests/test-transactions.lisp
+++ b/tests/test-transactions.lisp
@@ -90,6 +90,24 @@
            (is (null (fetch db "illegal"))))
       (close-database db))))
 
+(test nested-different-database-transaction-fails-closed
+  (let ((db-a (setup-db #P"/tmp/test-tek9-cross-db-a/"))
+        (db-b (setup-db #P"/tmp/test-tek9-cross-db-b/")))
+    (unwind-protect
+         (progn
+           (signals transaction-database-error
+             (with-write-transaction (db-a)
+               (put db-a (new-document :id "a" :value 1))
+               (put db-b (new-document :id "b" :value 2))))
+           (is (null (fetch db-a "a")))
+           (is (null (fetch db-b "b")))
+           (signals transaction-database-error
+             (with-read-transaction (db-a)
+               (with-read-transaction (db-b)
+                 (fetch db-b "b")))))
+      (close-database db-a)
+      (close-database db-b))))
+
 (test outer-transaction-preopens-first-use-document-databases
   (let* ((path #P"/tmp/test-tek9-first-use-dbis/")
          (db (setup-db path)))

--- a/tests/test-transactions.lisp
+++ b/tests/test-transactions.lisp
@@ -1,0 +1,132 @@
+(in-package :tek9-tests)
+(in-suite :tek9-tests)
+
+(test outer-write-transaction-commits-mixed-records
+  (let* ((path #P"/tmp/test-tek9-outer-commit/")
+         (db (setup-db path))
+         (graph-name "mixed"))
+    (unwind-protect
+         (progn
+           (register-index db
+                           "dtype"
+                           (lambda (document)
+                             (getf (doc-value document) :dtype)))
+           (with-write-transaction (db)
+             (put db (new-document :id "person-1"
+                                   :value '(:dtype "person" :name "Ada")))
+             (put-nodes db
+                        (list (make-instance 'node :id "a")
+                              (make-instance 'node :id "b"))
+                        :database-name graph-name)
+             (put-edge db
+                       (make-instance 'edge
+                                      :id "e1"
+                                      :source "a"
+                                      :predicate "knows"
+                                      :target "b")
+                       :database-name graph-name)
+             (put db (new-document :id "meta"
+                                   :value '(:revision 1))))
+           (is (equal '("person-1")
+                      (index-document-ids db "dtype" "person")))
+           (close-database db)
+           (setf db (open-database (new-database "test" :path path)))
+           (is (equal "Ada" (getf (fetch* db "person-1") :name)))
+           (is (= 1 (getf (fetch* db "meta") :revision)))
+           (is (equal '("e1")
+                      (fetch-node-edge-ids db "a" :database-name graph-name))))
+      (when (and db (db-is-open-p db))
+        (close-database db)))))
+
+(test outer-write-transaction-rolls-back-mixed-records
+  (let ((db (setup-db #P"/tmp/test-tek9-outer-rollback/"))
+        (graph-name "rollback"))
+    (unwind-protect
+         (progn
+           (register-index db
+                           "dtype"
+                           (lambda (document)
+                             (getf (doc-value document) :dtype)))
+           (signals error
+             (with-write-transaction (db)
+               (put db (new-document :id "person-1"
+                                     :value '(:dtype "person" :name "Ada")))
+               (put-nodes db
+                          (list (make-instance 'node :id "a")
+                                (make-instance 'node :id "b"))
+                          :database-name graph-name)
+               (put-edge db
+                         (make-instance 'edge
+                                        :id "e1"
+                                        :source "a"
+                                        :predicate "knows"
+                                        :target "b")
+                         :database-name graph-name)
+               (put db (new-document :id "meta" :value '(:revision 1)))
+               (error "inject rollback")))
+           (is (null (fetch db "person-1")))
+           (is (null (fetch db "meta")))
+           (is (null (index-document-ids db "dtype" "person")))
+           (is (null (fetch-node db "a" :database-name graph-name)))
+           (is (null (fetch-edge db "e1" :database-name graph-name)))
+           (is (null (fetch-node-edge-ids db "a" :database-name graph-name))))
+      (close-database db))))
+
+(test nested-tek9-transactions-reuse-compatible-boundary
+  (let ((db (setup-db #P"/tmp/test-tek9-nested-transaction/")))
+    (unwind-protect
+         (progn
+           (with-write-transaction (db)
+             (put db (new-document :id "outer" :value 1))
+             (with-write-transaction (db)
+               (put db (new-document :id "inner" :value 2)))
+             (with-read-transaction (db)
+               (is (= 2 (fetch* db "inner")))))
+           (is (= 1 (fetch* db "outer")))
+           (is (= 2 (fetch* db "inner")))
+           (signals transaction-mode-error
+             (with-read-transaction (db)
+               (put db (new-document :id "illegal" :value 3))))
+           (is (null (fetch db "illegal"))))
+      (close-database db))))
+
+(test edge-replacement-rolls-back-with-outer-transaction
+  (let ((db (setup-db #P"/tmp/test-tek9-edge-replace-rollback/"))
+        (graph-name "replace-rollback"))
+    (unwind-protect
+         (progn
+           (put-nodes db
+                      (list (make-instance 'node :id "a")
+                            (make-instance 'node :id "b")
+                            (make-instance 'node :id "c"))
+                      :database-name graph-name)
+           (put-edge db
+                     (make-instance 'edge
+                                    :id "edge"
+                                    :source "a"
+                                    :predicate "knows"
+                                    :target "b")
+                     :database-name graph-name)
+           (signals error
+             (with-write-transaction (db)
+               (put-edge db
+                         (make-instance 'edge
+                                        :id "edge"
+                                        :source "a"
+                                        :predicate "works-with"
+                                        :target "c")
+                         :database-name graph-name)
+               (error "inject rollback")))
+           (let ((edge (fetch-edge db "edge" :database-name graph-name)))
+             (is (string= "edge" (edge-id edge)))
+             (is (string= "b" (edge-target edge)))
+             (is (string= "knows" (edge-predicate edge))))
+           (is (equal '("b")
+                      (mapcar #'node-id
+                              (fetch-node-neighbors db "a"
+                                                    :database-name graph-name
+                                                    :predicate "knows"))))
+           (is (null (fetch-node-neighbors db "a"
+                                            :database-name graph-name
+                                            :predicate "works-with"))))
+      (close-database db))))

--- a/tests/test-transactions.lisp
+++ b/tests/test-transactions.lisp
@@ -90,6 +90,26 @@
            (is (null (fetch db "illegal"))))
       (close-database db))))
 
+(test outer-transaction-preopens-first-use-document-databases
+  (let* ((path #P"/tmp/test-tek9-first-use-dbis/")
+         (db (setup-db path)))
+    (unwind-protect
+         (progn
+           (with-write-transaction
+               (db :database-names '("metadata" "journal"))
+             (put db (new-document :id "meta" :value '(:revision 7))
+                  :database-name "metadata")
+             (put db (new-document :id "entry" :value '(:operation "commit"))
+                  :database-name "journal"))
+           (close-database db)
+           (setf db (open-database (new-database "test" :path path)))
+           (is (= 7 (getf (fetch* db "meta" :database-name "metadata") :revision)))
+           (is (string= "commit"
+                        (getf (fetch* db "entry" :database-name "journal")
+                              :operation))))
+      (when (and db (db-is-open-p db))
+        (close-database db)))))
+
 (test edge-replacement-rolls-back-with-outer-transaction
   (let ((db (setup-db #P"/tmp/test-tek9-edge-replace-rollback/"))
         (graph-name "replace-rollback"))


### PR DESCRIPTION
Implements #4 and #5 as the generic Tek9 prerequisites for `lost-rob0t/quasar#33`.

## Intent
- public composable read/write transaction boundary that reuses one compatible active Tek9 transaction;
- no accidental child commit boundary for normal public document/graph operations inside that outer transaction;
- explicit rejection of writes nested inside a Tek9 read-only transaction;
- pre-open fixed graph/view DBIs before the outer LMDB transaction because the loaded LMDB wrapper forbids first-time `GET-DB` during an active transaction;
- public graph edge fetch, namespace enumeration, node deletion with incident-edge cleanup, and graph namespace cleanup;
- preserve edge replacement IDs, parallel edges, secondary indexes, graph adjacency, reopen durability, and standalone APIs.

## TDD state
The first branch commit intentionally adds the invariant tests before the implementation. CI is expected to be red until the API lands; do not merge around it.

Closes #4.
Closes #5.