### PR TITLE
Nix: expose Tek9 as a consumable ASDF package

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -88,6 +88,12 @@ jobs:
           ref: ${{ github.event.pull_request.head.sha || github.sha }}
           fetch-depth: 1
 
+      - name: Install Nix
+        uses: cachix/install-nix-action@13d8dd58da0234aa297dedd986986ccb8e7f3e24 # v31
+
+      - name: Verify downstream Nix package contract
+        run: bash tests/nix-package-smoke.sh
+
       - name: Build source archive
         run: |
           VERSION="$(sed -n 's/.*:version "\([^"]*\)".*/\1/p' src/tek9.asd | head -n 1)"

--- a/README.org
+++ b/README.org
@@ -34,6 +34,37 @@ Then:
 (use-package :tek9)
 #+end_src
 
+*** Nix flakes
+
+Tek9 exposes =packages.<system>.tek9= and =packages.<system>.default= for
+=x86_64-linux= and =aarch64-linux=. A downstream flake can add Tek9 to an SBCL
+closure without a developer-local checkout:
+
+#+begin_src nix
+{
+  inputs = {
+    nixpkgs.url = "github:NixOS/nixpkgs/nixos-unstable";
+    tek9.url = "github:lost-rob0t/tek9";
+    tek9.inputs.nixpkgs.follows = "nixpkgs";
+  };
+
+  outputs = { nixpkgs, tek9, ... }:
+    let
+      system = "x86_64-linux";
+      pkgs = import nixpkgs { inherit system; };
+    in
+    {
+      packages.${system}.default = pkgs.sbcl.withPackages (_: [
+        tek9.packages.${system}.tek9
+      ]);
+    };
+}
+#+end_src
+
+The package propagates its Lisp dependencies and LMDB runtime library. Database
+paths remain application-owned mutable paths; they are never placed in the Nix
+store.
+
 ** Open a database
 
 The default LMDB map reserves 16 GiB of virtual address space and supports 64 named databases. The map is a capacity ceiling, not a preallocated 16 GiB data file.

--- a/flake.lock
+++ b/flake.lock
@@ -2,15 +2,16 @@
   "nodes": {
     "nixpkgs": {
       "locked": {
-        "lastModified": 1696418135,
-        "narHash": "sha256-KOKEcO7niN2TY0I4YBDd0GbPCgN35KqN7WTa2qT6y0M=",
-        "owner": "nixos",
+        "lastModified": 1787736819,
+        "narHash": "sha256-cV5xEJJK3BvhU8rEd4mC9UsmDi5qscv/kzGPhBRC5WA=",
+        "owner": "NixOS",
         "repo": "nixpkgs",
-        "rev": "fbd0cc5d53bf1e4e4f7ec7701f999c1f4350c367",
+        "rev": "9fbb54b33e91ee4ca368e35a78e0613c720600b3",
         "type": "github"
       },
       "original": {
-        "owner": "nixos",
+        "owner": "NixOS",
+        "ref": "nixos-unstable",
         "repo": "nixpkgs",
         "type": "github"
       }

--- a/flake.nix
+++ b/flake.nix
@@ -1,26 +1,60 @@
 {
-  description = "A NoSql Database in common lisp built ontop of LMDB.";
+  description = "Fast embedded Common Lisp document and graph database on LMDB.";
 
-  inputs = {
-    nixpkgs.url = "github:nixos/nixpkgs";
-  };
+  inputs.nixpkgs.url = "github:NixOS/nixpkgs/nixos-unstable";
 
   outputs = { self, nixpkgs }:
-  let
-    pkgs = nixpkgs.legacyPackages.x86_64-linux;
-  in {
-    devShell.x86_64-linux =
-      pkgs.mkShell {
-        buildInputs = with pkgs; [
-          pkg-config
-          sbcl
-          #lmdb.out
-          glib
-          openssl
-        ];
-        shellHook = ''
-              export LD_LIBRARY_PATH=${pkgs.lib.makeLibraryPath([pkgs.lmdb.out])}:${pkgs.lib.makeLibraryPath([pkgs.openssl])}
+    let
+      systems = [ "x86_64-linux" "aarch64-linux" ];
+      eachSystem = f: nixpkgs.lib.genAttrs systems (system: f system);
+    in
+    {
+      packages = eachSystem (system:
+        let
+          pkgs = import nixpkgs { inherit system; };
+          cl = pkgs.sbcl.pkgs;
+          tek9 = pkgs.sbcl.buildASDFSystem {
+            pname = "tek9";
+            version = "0.2.0";
+            src = self;
+            systems = [ "tek9" ];
+            nativeLibs = [ pkgs.lmdb ];
+            lispLibs = [
+              cl.alexandria
+              cl."bordeaux-threads"
+              cl.serapeum
+              cl.jsown
+              cl.lmdb
+              cl."cl-conspack"
+            ];
+          };
+        in
+        {
+          default = tek9;
+          inherit tek9;
+        });
+
+      devShells = eachSystem (system:
+        let
+          pkgs = import nixpkgs { inherit system; };
+        in
+        {
+          default = pkgs.mkShell {
+            packages = with pkgs; [
+              pkg-config
+              sbcl
+              glib
+              openssl
+              lmdb
+            ];
+            shellHook = ''
+              export LD_LIBRARY_PATH=${pkgs.lib.makeLibraryPath [ pkgs.lmdb pkgs.openssl ]}:''${LD_LIBRARY_PATH:-}
             '';
-      };
-  };
+          };
+        });
+
+      checks = eachSystem (system: {
+        package = self.packages.${system}.tek9;
+      });
+    };
 }

--- a/flake.nix
+++ b/flake.nix
@@ -55,6 +55,28 @@
 
       checks = eachSystem (system: {
         package = self.packages.${system}.tek9;
+        package-smoke =
+          let
+            pkgs = import nixpkgs { inherit system; };
+            tek9 = self.packages.${system}.tek9;
+            sbclWithTek9 = pkgs.sbcl.withPackages (_: [ tek9 ]);
+          in
+          pkgs.runCommand "tek9-package-smoke" {
+            nativeBuildInputs = [ sbclWithTek9 ];
+          } ''
+            export HOME="$TMPDIR/home"
+            mkdir -p "$HOME" "$TMPDIR/consumer"
+            cd "$TMPDIR/consumer"
+
+            sbcl --noinform --non-interactive \
+              --eval '(require :asdf)' \
+              --eval '(asdf:load-system :tek9)' \
+              --eval '(assert (find-package :tek9))' \
+              --eval "(let ((database (tek9:open-database (tek9:new-database \"smoke\" :path #P\"$TMPDIR/database/\")))) (tek9:close-database database))"
+
+            test -f "$TMPDIR/database/data.mdb"
+            touch "$out"
+          '';
       });
     };
 }

--- a/flake.nix
+++ b/flake.nix
@@ -13,18 +13,21 @@
         let
           pkgs = import nixpkgs { inherit system; };
           cl = pkgs.sbcl.pkgs;
+          lmdb = cl.lmdb.overrideLispAttrs (old: {
+            nativeLibs = (old.nativeLibs or [ ]) ++ [ pkgs.lmdb.out ];
+          });
           tek9 = pkgs.sbcl.buildASDFSystem {
             pname = "tek9";
             version = "0.2.0";
             src = self;
             systems = [ "tek9" ];
-            nativeLibs = [ pkgs.lmdb ];
+            nativeLibs = [ pkgs.lmdb.out ];
             lispLibs = [
               cl.alexandria
               cl."bordeaux-threads"
               cl.serapeum
               cl.jsown
-              cl.lmdb
+              lmdb
               cl."cl-conspack"
             ];
           };
@@ -48,7 +51,7 @@
               lmdb
             ];
             shellHook = ''
-              export LD_LIBRARY_PATH=${pkgs.lib.makeLibraryPath [ pkgs.lmdb pkgs.openssl ]}:''${LD_LIBRARY_PATH:-}
+              export LD_LIBRARY_PATH=${pkgs.lib.makeLibraryPath [ pkgs.lmdb.out pkgs.openssl ]}:''${LD_LIBRARY_PATH:-}
             '';
           };
         });

--- a/tests/nix-package-smoke.sh
+++ b/tests/nix-package-smoke.sh
@@ -9,15 +9,7 @@ cd "$repo_root"
 nix build --no-link .#tek9
 nix build --no-link .#default
 
-# A downstream consumer must be able to load :tek9 with only the package's
-# exported ASDF registry, outside the Tek9 source tree.
-consumer="$(mktemp -d)"
-trap 'rm -rf "$consumer"' EXIT
-cd "$consumer"
-
-tek9_pkg="$(nix build --no-link --print-out-paths "$repo_root#tek9")"
-CL_SOURCE_REGISTRY="$tek9_pkg//" \
-  nix shell nixpkgs#sbcl -c sbcl --non-interactive \
-    --eval '(require :asdf)' \
-    --eval '(asdf:load-system :tek9)' \
-    --eval '(assert (find-package :tek9))'
+# The flake check wraps the package in a downstream SBCL, changes to an empty
+# consumer directory, loads :tek9 from the package closure, and opens a mutable
+# LMDB database under the build directory rather than the immutable Nix store.
+nix build --no-link .#checks."$(nix eval --raw --impure --expr builtins.currentSystem)".package-smoke

--- a/tests/nix-package-smoke.sh
+++ b/tests/nix-package-smoke.sh
@@ -1,0 +1,23 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+repo_root="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+cd "$repo_root"
+
+# RED contract for #7: Tek9 must be consumable as a flake package, not only
+# through a developer checkout/devShell.
+nix build --no-link .#tek9
+nix build --no-link .#default
+
+# A downstream consumer must be able to load :tek9 with only the package's
+# exported ASDF registry, outside the Tek9 source tree.
+consumer="$(mktemp -d)"
+trap 'rm -rf "$consumer"' EXIT
+cd "$consumer"
+
+tek9_pkg="$(nix build --no-link --print-out-paths "$repo_root#tek9")"
+CL_SOURCE_REGISTRY="$tek9_pkg//" \
+  nix shell nixpkgs#sbcl -c sbcl --non-interactive \
+    --eval '(require :asdf)' \
+    --eval '(asdf:load-system :tek9)' \
+    --eval '(assert (find-package :tek9))'


### PR DESCRIPTION
Closes #7

Supersedes draft PR #8 at the exact same commit because GitHub's ready-for-review mutation is currently failing. No code was rebased or rewritten.

## Exact-head validation

Head: `5931490eee6f160edf37830fbe96e7142fe68533`

CI run 123 on this exact commit passed:

- `tests (ubuntu-22.04)`
- `tests (ubuntu-24.04)`
- downstream Nix `package-smoke`
- `benchmark-regression`
- `merge-gate`

## Result

- exports `packages.{x86_64-linux,aarch64-linux}.{tek9,default}`;
- loads `:tek9` in a downstream `sbcl.withPackages` closure;
- propagates Lisp dependencies and `pkgs.lmdb.out`;
- keeps mutable LMDB state outside the Nix store;
- preserves the existing development shell;
- pins nixpkgs and documents downstream flake consumption.
