### PR TITLE
views: allow materialized views to select a named source database

### DIFF
--- a/src/package.lisp
+++ b/src/package.lisp
@@ -45,6 +45,7 @@
    :delete-edge :delete-node :clear-graph
    ;; views
    :database-view :new-view :add-view :delete-view :clear-view :create-view-db
+   :view-source-database-name
    :define-map :define-reduce :insert-results :apply-view
    :apply-view-to-database :with-views
    :view-get :view-rows :map-view :reduce-view

--- a/src/views.lisp
+++ b/src/views.lisp
@@ -20,17 +20,29 @@
 (defclass database-view ()
   ((name :initform "" :type string :accessor view-name :initarg :name)
    (map-fn :initform nil :accessor view-map :initarg :map)
-   (reduce-fn :initform nil :accessor view-reduce :initarg :reduce)))
+   (reduce-fn :initform nil :accessor view-reduce :initarg :reduce)
+   (source-database-name :initform +main-name+
+                         :type string
+                         :reader view-source-database-name
+                         :initarg :source-database-name)))
 
 (defmethod add-view ((db database) (view database-view))
   (setf (gethash (view-name view) (db-views db)) view)
   view)
 
-(defun new-view (name map-fn &optional reduce-fn)
+(defun new-view (name map-fn &optional reduce-fn
+                 &key (source-database-name +main-name+))
+  "Create a materialized view over SOURCE-DATABASE-NAME.
+
+Existing callers that omit SOURCE-DATABASE-NAME continue to map Tek9's primary
+document database. The source selection affects both full rebuild and
+incremental application; materialized rows remain stored under VIEW/<NAME>."
+  (check-type source-database-name string)
   (make-instance 'database-view
                  :map map-fn
                  :reduce reduce-fn
-                 :name name))
+                 :name name
+                 :source-database-name source-database-name))
 
 (defmacro define-map (view &body body)
   "Install a mapper on VIEW while binding caller-visible DOC and EMIT symbols.
@@ -80,6 +92,14 @@ symbols present in BODY so normal exported-macro use works across packages."
                :key-encoding :utf-8
                :value-encoding :octets))
 
+(defun view-source-db (database view)
+  "Return VIEW's existing source DBI without silently creating a missing source."
+  (database-db database
+               (view-source-database-name view)
+               :if-does-not-exist :error
+               :key-encoding :utf-8
+               :value-encoding :octets))
+
 (defun clear-view (database view)
   (let ((db (create-view-db database view))
         (keys nil))
@@ -108,8 +128,8 @@ The named LMDB DBI is retained because closing/deleting open DBIs is unsafe."
     results))
 
 (defun apply-view-to-database (database view)
-  "Rebuild VIEW in a single write transaction."
-  (let ((source (%main-db database +main-name+))
+  "Rebuild VIEW from its declared source database in a single write transaction."
+  (let ((source (view-source-db database view))
         (target (create-view-db database view))
         (keys nil))
     (with-database (database :write t)
@@ -132,8 +152,8 @@ The named LMDB DBI is retained because closing/deleting open DBIs is unsafe."
     view))
 
 (defun apply-view (database view doc-ids)
-  "Incrementally apply VIEW to DOC-IDS in one write transaction."
-  (let ((source (%main-db database +main-name+))
+  "Incrementally apply VIEW to DOC-IDS from its declared source database."
+  (let ((source (view-source-db database view))
         (target (create-view-db database view)))
     (with-database (database :write t)
       (dolist (id doc-ids)

--- a/tests/test-views.lisp
+++ b/tests/test-views.lisp
@@ -119,3 +119,16 @@
                         ("job-3" . :failed))
                       (view-rows db view))))
       (close-database db))))
+
+(test view-unknown-source-database-fails-closed
+  (let ((db (setup-db #P"/tmp/test-tek9-view-missing-source/")))
+    (unwind-protect
+         (let ((view (new-view "missing-source"
+                               nil
+                               nil
+                               :source-database-name "does-not-exist")))
+           (define-map view
+             (emit (doc-id doc) (doc-value doc)))
+           (signals error
+             (apply-view-to-database db view)))
+      (close-database db))))

--- a/tests/test-views.lisp
+++ b/tests/test-views.lisp
@@ -86,3 +86,36 @@
            (signals view-reducer-missing
              (reduce-view db view)))
       (close-database db))))
+
+(test view-selects-named-source-database
+  (let ((db (setup-db #P"/tmp/test-tek9-view-named-source/")))
+    (unwind-protect
+         (let ((view (new-view "outbox-by-state"
+                               nil
+                               nil
+                               :source-database-name "outbox")))
+           (define-map view
+             (emit (doc-id doc) (getf (doc-value doc) :state)))
+           (add-view db view)
+
+           ;; The source fixtures exist only in OUTBOX, never in the primary DB.
+           (put db
+                (new-document :id "job-1" :value '(:state :pending))
+                :database-name "outbox")
+           (put db
+                (new-document :id "job-2" :value '(:state :sent))
+                :database-name "outbox")
+           (apply-view-to-database db view)
+           (is (equal '(("job-1" . :pending) ("job-2" . :sent))
+                      (view-rows db view)))
+
+           ;; Incremental application must read the same declared named source.
+           (put db
+                (new-document :id "job-3" :value '(:state :failed))
+                :database-name "outbox")
+           (apply-view db view '("job-3"))
+           (is (equal '(("job-1" . :pending)
+                        ("job-2" . :sent)
+                        ("job-3" . :failed))
+                      (view-rows db view))))
+      (close-database db))))


### PR DESCRIPTION
Implements #15 as the minimal generic upstream dependency required by lost-rob0t/hackmode#15.

RED-first evidence: exact test-only head `194df03706afa7ecbadad91c2461a0ea02c202ca` reached the real `Load and test Tek9` step and failed on both Ubuntu 22.04 and 24.04 jobs. Setup and benchmark-tool validation were green before the suite failure, so this is not environment noise.

Implementation:
- `database-view` carries an explicit source database name, defaulting to the primary DB for backward compatibility;
- `new-view` accepts `:source-database-name` without changing existing callers;
- full rebuild and incremental application resolve the same declared source;
- source lookup uses LMDB `:if-does-not-exist :error`, so a miss fails closed instead of silently creating/reading the primary DB;
- materialized rows remain under `view/<name>` and public `view-get` / `view-rows` / `map-view` behavior is unchanged;
- the source identity accessor is exported for consumers that need to inspect configuration.

Tests cover named-source rebuild, incremental application, public row reads, unchanged primary-source behavior, and explicit failure for an unknown source. No Hackmode-specific view names or outbox semantics are introduced into Tek9.

Current candidate head: `18f0e81575c9774b3a277b2eba56319ac67ea8cc`. Merge only if fresh exact-head CI is fully green.